### PR TITLE
feat: Add `ns1_zones` table

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,8 @@ spec:
   path: "localhost:7777"
   tables: ['*']
   destinations: ['file']
+  spec:
+    apiKey: '1234'
 ---
 kind: destination
 spec:

--- a/src/nsone.ts
+++ b/src/nsone.ts
@@ -1,0 +1,53 @@
+import type { Logger } from 'winston';
+
+const apiPrefix = 'https://api.nsone.net/v1';
+
+async function nsoneRequest<T extends object>(
+	logger: Logger,
+	method: string,
+	url: string,
+	apiKey: string,
+): Promise<T> {
+	const headers = {
+		'X-NSONE-Key': apiKey,
+	};
+	const fullUrl = `${apiPrefix}${url}`;
+	logger.info('Making request to NSone', method, fullUrl);
+
+	const response = await fetch(fullUrl, { method, headers });
+
+	if (response.ok) {
+		return (await response.json()) as T;
+	}
+
+	logger.info(`Error: ${await response.text()}`);
+	throw new Error('Non 200 status code returned from request');
+}
+
+export type ZoneSummary = {
+	id: string;
+	ttl: number;
+	nx_ttl: number;
+	retry: number;
+	zone: string;
+	refresh: number;
+	expiry: number;
+	dns_servers: string[];
+	networks: number[];
+	network_pools: string[];
+	meta: Record<string, unknown>;
+	hostmaster: string;
+};
+
+/**
+ * Returns a list of all active DNS zones along with basic zone configuration details for each.
+ *
+ * @see https://ns1.com/api?docId=2184
+ * @see https://jsapi.apiary.io/apis/ns1api/introduction/api-simulator-tutorial.html
+ */
+export function getZones(
+	logger: Logger,
+	apiKey: string,
+): Promise<ZoneSummary[]> {
+	return nsoneRequest<ZoneSummary[]>(logger, 'GET', '/zones', apiKey);
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@ import {
 	newUnimplementedDestination,
 } from '@cloudquery/plugin-sdk-javascript/plugin/plugin';
 import type {
+	Client,
 	NewClientFunction,
 	Plugin,
 	SyncOptions,
@@ -80,21 +81,21 @@ export const plugin = () => {
 		},
 	};
 
-	const newClient: NewClientFunction = async (
+	const newClient: NewClientFunction = (
 		logger,
 		spec,
 		{ noConnection },
-	) => {
+	): Promise<Client> => {
 		pluginClient.spec = parseSpec(spec);
 		pluginClient.client = { id: () => 'ns1' };
 
 		if (noConnection) {
 			pluginClient.allTables = [];
-			return pluginClient;
+			return Promise.resolve(pluginClient);
 		}
 
-		pluginClient.allTables = await getTables(logger, pluginClient.spec);
-		return pluginClient;
+		pluginClient.allTables = getTables(logger, pluginClient.spec);
+		return Promise.resolve(pluginClient);
 	};
 
 	pluginClient.plugin = newPlugin('NS1', version, newClient);

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -5,6 +5,11 @@ export type Spec = {
 
 export const parseSpec = (spec: string): Spec => {
 	const parsed = JSON.parse(spec) as Partial<Spec>;
-	const { concurrency = 10_000, apiKey = '' } = parsed;
+	const { concurrency = 10_000, apiKey } = parsed;
+
+	if (apiKey === undefined) {
+		throw new Error('API key not specified.');
+	}
+
 	return { concurrency, apiKey };
 };


### PR DESCRIPTION
## What does this change?
Adds the table `ns1_zones`.

The data will look [something like this](https://jsapi.apiary.io/apis/ns1api/introduction/api-simulator-tutorial.html):

```json
[
  {
    "id": "520422af9f782d37dffb588b",
    "ttl": 3600,
    "nx_ttl": 3600,
    "retry": 7200,
    "zone": "example.com",
    "refresh": 43200,
    "expiry": 1209600,
    "dns_servers": [
      "dns1.p03.nsone.net",
      "dns2.p03.nsone.net",
      "dns3.p03.nsone.net",
      "dns4.p03.nsone.net"
    ],
    "networks": [
      0
    ],
    "network_pools": [
      "p03"
    ],
    "meta": {},
    "hostmaster": "hostmaster@nsone.net"
  },
  {
    "id": "520422c99f782d37dffb5892",
    "ttl": 3600,
    "nx_ttl": 3600,
    "retry": 7200,
    "zone": "nsoneisgreat.com",
    "refresh": 43200,
    "expiry": 1209600,
    "dns_servers": [
      "dns1.p04.nsone.net",
      "dns2.p04.nsone.net",
      "dns3.p04.nsone.net",
      "dns4.p04.nsone.net"
    ],
    "networks": [
      0
    ],
    "network_pools": [
      "p04"
    ],
    "meta": {},
    "hostmaster": "hostmaster@nsone.net"
  }
]
```