### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

