### PR TITLE
Add .github/CODEOWNERS file for devx-reliability-and-ops team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/devx-reliability-and-ops


### PR DESCRIPTION
Adds a CODEOWNERS file to assign @guardian/devx-reliability-and-ops as code owners for the repository.